### PR TITLE
Move docs to subdomain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,13 @@
 node_modules/
 .astro/
 deploy/
+deploy-docs/
 tmp/
 .beads/
 .runtime/
 
 # Generated tools output
 tools/og-preview.html
+
+# Generated docs pages for subdomain build
+src-docs/pages/

--- a/astro.config.docs.mjs
+++ b/astro.config.docs.mjs
@@ -1,0 +1,26 @@
+/**
+ * Astro configuration for the docs subdomain (docs.gastownhall.ai).
+ *
+ * This config is used when building the docs site separately for the subdomain.
+ * The docs pages are generated at root level (not under /docs/).
+ *
+ * Usage: astro build --config astro.config.docs.mjs
+ */
+import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
+
+export default defineConfig({
+  site: 'https://docs.gastownhall.ai',
+  outDir: './deploy-docs',
+  srcDir: './src-docs',
+  build: {
+    assets: '_assets'
+  },
+  integrations: [
+    sitemap({
+      changefreq: 'weekly',
+      priority: 0.7,
+      lastmod: new Date(),
+    })
+  ]
+});

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "deploy": "npm run build && wrangler pages deploy deploy --project-name=gastownhall-website",
     "astro": "astro",
     "shred-docs": "node scripts/shred-docs.mjs",
+    "shred-docs:subdomain": "node scripts/shred-docs.mjs --subdomain",
+    "build:docs": "npm run shred-docs:subdomain && npm run astro -- build --config astro.config.docs.mjs",
+    "deploy:docs": "npm run build:docs && wrangler pages deploy deploy-docs --project-name=gastownhall-docs",
     "llms": "node scripts/generate-llms.mjs",
     "test": "node --test scripts/lib/__tests__/*.test.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "shred-docs": "node scripts/shred-docs.mjs",
     "shred-docs:subdomain": "node scripts/shred-docs.mjs --subdomain",
     "build:docs": "npm run shred-docs:subdomain && npm run astro -- build --config astro.config.docs.mjs",
-    "deploy:docs": "npm run build:docs && wrangler pages deploy deploy-docs --project-name=gastownhall-docs",
+    "deploy:docs": "npm run build:docs && wrangler pages deploy deploy-docs --project-name=gastown-docs",
     "llms": "node scripts/generate-llms.mjs",
     "test": "node --test scripts/lib/__tests__/*.test.mjs"
   },

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,8 @@
+# Redirect docs paths to docs subdomain
+# Cloudflare Pages redirect format: from to [status]
+# See: https://developers.cloudflare.com/pages/configuration/redirects/
+
+# Redirect all /docs/* paths to docs.gastownhall.ai/*
+/docs https://docs.gastownhall.ai/ 301
+/docs/ https://docs.gastownhall.ai/ 301
+/docs/* https://docs.gastownhall.ai/:splat 301

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -7,7 +7,9 @@ Website: https://gastownhall.ai
 ## Main Pages
 
 - [Home](https://gastownhall.ai/)
+- [About - Gas Town Hall](https://gastownhall.ai/about): About Gas Town Hall and its creator Chris Sells.
 - [Privacy Policy - Gas Town Hall](https://gastownhall.ai/privacy): Privacy policy for Gas Town Hall. We respect your privacy and collect minimal data.
+- [Terms of Service - Gas Town Hall](https://gastownhall.ai/terms): Terms of Service for Gas Town Hall website and community.
 
 ## Blog
 
@@ -19,38 +21,38 @@ Website: https://gastownhall.ai
 
 ## Documentation
 
-- [Documentation](https://gastownhall.ai/docs): Gas Town documentation and guides
-- [Beads-Native Messaging](https://gastownhall.ai/docs/beads-native-messaging): This document describes the beads-native messaging system for Gas Town, which replaces the file-based messaging configuration with persistent beads stored in th
-- [Formula Resolution Architecture](https://gastownhall.ai/docs/formula-resolution): > Where formulas live, how they
-- [Gas Town Glossary](https://gastownhall.ai/docs/glossary): Gas Town is an agentic development environment for managing multiple Claude Code instances simultaneously using the `gt` and `bd` (Beads) binaries, coordinated 
-- [Installing Gas Town](https://gastownhall.ai/docs/installing): Complete setup guide for Gas Town multi-agent orchestrator.
-- [Mol Mall Design](https://gastownhall.ai/docs/mol-mall-design): > A marketplace for Gas Town formulas
-- [Gas Town Reference](https://gastownhall.ai/docs/reference): Technical reference for Gas Town internals. Read the README first.
-- [Why These Features?](https://gastownhall.ai/docs/why-these-features): > Gas Town
+- [Understanding Gas Town](https://docs.gastownhall.ai): This document provides a conceptual overview of Gas Town
+- [Beads-Native Messaging](https://docs.gastownhall.ai/beads-native-messaging): This document describes the beads-native messaging system for Gas Town, which replaces the file-based messaging configuration with persistent beads stored in th
+- [Formula Resolution Architecture](https://docs.gastownhall.ai/formula-resolution): > Where formulas live, how they
+- [Gas Town Glossary](https://docs.gastownhall.ai/glossary): Gas Town is an agentic development environment for managing multiple Claude Code instances simultaneously using the `gt` and `bd` (Beads) binaries, coordinated 
+- [Installing Gas Town](https://docs.gastownhall.ai/installing): Complete setup guide for Gas Town multi-agent orchestrator.
+- [Mol Mall Design](https://docs.gastownhall.ai/mol-mall-design): > A marketplace for Gas Town formulas
+- [Gas Town Reference](https://docs.gastownhall.ai/reference): Technical reference for Gas Town internals. Read the README first.
+- [Why These Features?](https://docs.gastownhall.ai/why-these-features): > Gas Town
 
 ## Core Concepts
 
-- [Convoys](https://gastownhall.ai/docs/concepts/convoy): Convoys are the primary unit for tracking batched work across rigs.
-- [Agent Identity and Attribution](https://gastownhall.ai/docs/concepts/identity): > Canonical format for agent identity in Gas Town
-- [Molecules](https://gastownhall.ai/docs/concepts/molecules): Molecules are workflow templates that coordinate multi-step work in Gas Town.
-- [Polecat Lifecycle](https://gastownhall.ai/docs/concepts/polecat-lifecycle): > Understanding the three-layer architecture of polecat workers
-- [The Propulsion Principle](https://gastownhall.ai/docs/concepts/propulsion-principle): > **If you find something on your hook, YOU RUN IT.**
+- [Convoys](https://docs.gastownhall.ai/concepts/convoy): Convoys are the primary unit for tracking batched work across rigs.
+- [Agent Identity and Attribution](https://docs.gastownhall.ai/concepts/identity): > Canonical format for agent identity in Gas Town
+- [Molecules](https://docs.gastownhall.ai/concepts/molecules): Molecules are workflow templates that coordinate multi-step work in Gas Town.
+- [Polecat Lifecycle](https://docs.gastownhall.ai/concepts/polecat-lifecycle): > Understanding the three-layer architecture of polecat workers
+- [The Propulsion Principle](https://docs.gastownhall.ai/concepts/propulsion-principle): > **If you find something on your hook, YOU RUN IT.**
 
 ## Architecture & Design
 
-- [Gas Town Architecture](https://gastownhall.ai/docs/design/architecture): Technical architecture for Gas Town multi-agent workspace management.
-- [Convoy Lifecycle Design](https://gastownhall.ai/docs/design/convoy-lifecycle): > Making convoys actively converge on completion.
-- [Dog Pool Architecture for Concurrent Shutdown Dances](https://gastownhall.ai/docs/design/dog-pool-architecture): > Design document for gt-fsld8
-- [Gas Town Escalation Protocol](https://gastownhall.ai/docs/design/escalation): > Reference for escalation paths in Gas Town
-- [Escalation System Design](https://gastownhall.ai/docs/design/escalation-system): > Detailed design for the Gas Town unified escalation system. > Written 2026-01-11, crew/george session. > Parent epic: gt-i9r20
-- [Federation Architecture](https://gastownhall.ai/docs/design/federation): > **Status: Design spec - not yet implemented**
-- [Gas Town Mail Protocol](https://gastownhall.ai/docs/design/mail-protocol): > Reference for inter-agent mail communication in Gas Town
-- [Operational State in Gas Town](https://gastownhall.ai/docs/design/operational-state): > Managing runtime state through events and labels.
-- [Plugin System Design](https://gastownhall.ai/docs/design/plugin-system): > Design document for the Gas Town plugin system. > Written 2026-01-11, crew/george session.
-- [Property Layers: Multi-Level Configuration](https://gastownhall.ai/docs/design/property-layers): > Implementation guide for Gas Town
-- [Daemon/Boot/Deacon Watchdog Chain](https://gastownhall.ai/docs/design/watchdog-chain): > Autonomous health monitoring and recovery in Gas Town.
+- [Gas Town Architecture](https://docs.gastownhall.ai/design/architecture): Technical architecture for Gas Town multi-agent workspace management.
+- [Convoy Lifecycle Design](https://docs.gastownhall.ai/design/convoy-lifecycle): > Making convoys actively converge on completion.
+- [Dog Pool Architecture for Concurrent Shutdown Dances](https://docs.gastownhall.ai/design/dog-pool-architecture): > Design document for gt-fsld8
+- [Gas Town Escalation Protocol](https://docs.gastownhall.ai/design/escalation): > Reference for escalation paths in Gas Town
+- [Escalation System Design](https://docs.gastownhall.ai/design/escalation-system): > Detailed design for the Gas Town unified escalation system. > Written 2026-01-11, crew/george session. > Parent epic: gt-i9r20
+- [Federation Architecture](https://docs.gastownhall.ai/design/federation): > **Status: Design spec - not yet implemented**
+- [Gas Town Mail Protocol](https://docs.gastownhall.ai/design/mail-protocol): > Reference for inter-agent mail communication in Gas Town
+- [Operational State in Gas Town](https://docs.gastownhall.ai/design/operational-state): > Managing runtime state through events and labels.
+- [Plugin System Design](https://docs.gastownhall.ai/design/plugin-system): > Design document for the Gas Town plugin system. > Written 2026-01-11, crew/george session.
+- [Property Layers: Multi-Level Configuration](https://docs.gastownhall.ai/design/property-layers): > Implementation guide for Gas Town
+- [Daemon/Boot/Deacon Watchdog Chain](https://docs.gastownhall.ai/design/watchdog-chain): > Autonomous health monitoring and recovery in Gas Town.
 
 ## Examples
 
-- [Towers of Hanoi Demo](https://gastownhall.ai/docs/examples/hanoi-demo): A durability proof demonstrating Gas Town
+- [Towers of Hanoi Demo](https://docs.gastownhall.ai/examples/hanoi-demo): A durability proof demonstrating Gas Town
 

--- a/scripts/generate-llms.mjs
+++ b/scripts/generate-llms.mjs
@@ -75,9 +75,17 @@ function groupPages(pages) {
 
 /**
  * Formats a page entry as a markdown list item.
+ * Docs pages use the docs subdomain URL.
  */
 function formatPageEntry(page) {
-  const url = `${site.url}${page.urlPath}`;
+  let url;
+  if (page.urlPath.startsWith('/docs')) {
+    // Transform /docs/... to docs.gastownhall.ai/...
+    const docsPath = page.urlPath.replace(/^\/docs\/?/, '/');
+    url = `${site.docsUrl}${docsPath === '/' ? '' : docsPath}`;
+  } else {
+    url = `${site.url}${page.urlPath}`;
+  }
   const suffix = page.description ? `: ${page.description}` : '';
   return `- [${page.title}](${url})${suffix}`;
 }

--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -21,6 +21,7 @@ export const paths = {
 export const site = {
   name: 'Gas Town Hall',
   url: 'https://gastownhall.ai',
+  docsUrl: 'https://docs.gastownhall.ai',
   description: 'Gas Town Hall - Documentation and resources for Gas Town',
   twitterHandle: '@gastownhall',
 };

--- a/scripts/lib/markdown.mjs
+++ b/scripts/lib/markdown.mjs
@@ -109,9 +109,10 @@ export function escapeHtml(text) {
  *
  * @param {string} md - Markdown content
  * @param {Map<string, string>} [routeMap] - Optional map of filename → route for .md link conversion
+ * @param {boolean} [subdomain=false] - If true, use subdomain-style routes (no /docs/ prefix)
  * @returns {string} HTML content
  */
-export function convertMarkdownToHtml(md, routeMap) {
+export function convertMarkdownToHtml(md, routeMap, subdomain = false) {
   let html = md;
 
   // Extract code blocks first to protect them from other conversions
@@ -133,7 +134,7 @@ export function convertMarkdownToHtml(md, routeMap) {
   // Now apply conversions safely
   html = convertHeaders(html);
   html = convertEmphasis(html);
-  html = convertLinks(html, routeMap);
+  html = convertLinks(html, routeMap, subdomain);
   html = convertLists(html);
   html = convertTables(html);
   html = wrapParagraphs(html);
@@ -171,9 +172,10 @@ function convertEmphasis(html) {
  *
  * @param {string} html - HTML content with markdown links
  * @param {Map<string, string>} [routeMap] - Optional map of filename → route
+ * @param {boolean} [subdomain=false] - If true, use subdomain-style routes (no /docs/ prefix)
  * @returns {string} HTML with converted links
  */
-function convertLinks(html, routeMap) {
+function convertLinks(html, routeMap, subdomain = false) {
   return html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, text, href) => {
     let displayText = text;
 
@@ -192,7 +194,9 @@ function convertLinks(html, routeMap) {
       }
       // Link to non-existent file - keep as-is but remove .md extension
       const slug = filename.replace(/\.md$/i, '').toLowerCase().replace(/[^a-z0-9]+/g, '-');
-      return `<a href="/docs/${slug}">${displayText}</a>`;
+      // In subdomain mode, links are at root level
+      const fallbackRoute = subdomain ? `/${slug}` : `/docs/${slug}`;
+      return `<a href="${fallbackRoute}">${displayText}</a>`;
     }
     return `<a href="${href}">${displayText}</a>`;
   });

--- a/src-docs/layouts/BaseLayout.astro
+++ b/src-docs/layouts/BaseLayout.astro
@@ -13,7 +13,7 @@ interface Props {
 const {
   title,
   description = site.description,
-  image = '/og-image.jpg',
+  image = '/og-image.svg',
   type = 'website',
   publishedDate,
   modifiedDate
@@ -28,7 +28,7 @@ const organizationSchema = {
   "@type": "Organization",
   "name": site.name,
   "url": site.url,
-  "logo": `${site.url}/favicon.svg`,
+  "logo": `${site.mainSiteUrl}/favicon.svg`,
   "sameAs": [
     social.github,
     social.x,
@@ -85,7 +85,7 @@ const schemas = isHomePage
     <meta name="robots" content="index, follow" />
     <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
     <meta name="author" content="Chris Sells" />
-    <meta name="keywords" content="Gas Town, AI coding agents, orchestration, developer tools, AI workflow, coding automation" />
+    <meta name="keywords" content="Gas Town, AI coding agents, orchestration, developer tools, AI workflow, coding automation, documentation" />
 
     <link rel="canonical" href={canonicalUrl} />
 
@@ -94,10 +94,7 @@ const schemas = isHomePage
     <meta property="og:url" content={canonicalUrl} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
-    <meta property="og:image" content={`${site.url}${image}`} />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="Mayor of Gas Town - AI-powered development workflows" />
+    <meta property="og:image" content={`${site.mainSiteUrl}${image}`} />
     <meta property="og:site_name" content={site.name} />
     <meta property="og:locale" content="en_US" />
     {publishedDate && <meta property="article:published_time" content={publishedDate} />}
@@ -108,13 +105,13 @@ const schemas = isHomePage
     <meta name="twitter:url" content={canonicalUrl} />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
-    <meta name="twitter:image" content={`${site.url}${image}`} />
+    <meta name="twitter:image" content={`${site.mainSiteUrl}${image}`} />
     <meta name="twitter:site" content={site.twitterHandle} />
     <meta name="twitter:creator" content="@csells" />
 
-    <!-- Favicons -->
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <!-- Favicons (served from main site) -->
+    <link rel="icon" type="image/svg+xml" href={`${site.mainSiteUrl}/favicon.svg`} />
+    <link rel="apple-touch-icon" href={`${site.mainSiteUrl}/apple-touch-icon.png`} />
 
     <title>{title}</title>
 
@@ -122,7 +119,8 @@ const schemas = isHomePage
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 
-    <link rel="stylesheet" href="/styles/global.css" />
+    <!-- Load styles from main site -->
+    <link rel="stylesheet" href={`${site.mainSiteUrl}/styles/global.css`} />
 
     <!-- JSON-LD Structured Data -->
     {schemas.map(schema => (
@@ -136,9 +134,9 @@ const schemas = isHomePage
     <a href="#main-content" class="skip-link">Skip to main content</a>
     <header class="site-header">
       <nav>
-        <a href="/" class="logo">{site.name}</a>
+        <a href={site.mainSiteUrl} class="logo">Gas Town Hall</a>
         <div class="nav-links">
-          <a href={site.docsUrl}>Docs</a>
+          <a href="/">Docs</a>
           <a href={social.discord} target="_blank" rel="noopener">Discord</a>
           <a href={social.x} target="_blank" rel="noopener">X</a>
           <a href={social.github} target="_blank" rel="noopener">GitHub</a>
@@ -150,7 +148,7 @@ const schemas = isHomePage
     </main>
     <footer class="site-footer">
       <p>&copy; 2025-{new Date().getFullYear()} Chris Sells · Gas Town content &copy; Steve Yegge, used with permission</p>
-      <p><a href="/privacy">Privacy</a> · <a href="/terms">Terms</a> · <a href="/about">About</a></p>
+      <p><a href={`${site.mainSiteUrl}/privacy`}>Privacy</a> · <a href={`${site.mainSiteUrl}/terms`}>Terms</a> · <a href={`${site.mainSiteUrl}/about`}>About</a></p>
     </footer>
   </body>
 </html>

--- a/src-docs/layouts/DocsLayout.astro
+++ b/src-docs/layouts/DocsLayout.astro
@@ -1,0 +1,178 @@
+---
+import BaseLayout from './BaseLayout.astro';
+
+interface Props {
+  title: string;
+  description?: string;
+}
+
+const { title, description } = Astro.props;
+const currentPath = Astro.url.pathname;
+---
+
+<BaseLayout title={`${title} | Gas Town Docs`} description={description}>
+  <div class="docs-container">
+    <aside class="docs-sidebar">
+      <nav>
+        <h3>Overview</h3>
+        <ul>
+          <li><a href="/" class:list={[{ active: currentPath === '/' }]}>Overview</a></li>
+          <li><a href="/glossary" class:list={[{ active: currentPath.includes('/glossary') }]}>Glossary</a></li>
+          <li><a href="/reference" class:list={[{ active: currentPath.includes('/reference') }]}>Reference</a></li>
+          <li><a href="/installing" class:list={[{ active: currentPath.includes('/installing') }]}>Installing</a></li>
+        </ul>
+
+        <h3>Concepts</h3>
+        <ul>
+          <li><a href="/concepts/convoy" class:list={[{ active: currentPath.includes('/concepts/convoy') }]}>Convoy</a></li>
+          <li><a href="/concepts/identity" class:list={[{ active: currentPath.includes('/concepts/identity') }]}>Identity</a></li>
+          <li><a href="/concepts/molecules" class:list={[{ active: currentPath.includes('/concepts/molecules') }]}>Molecules</a></li>
+          <li><a href="/concepts/polecat-lifecycle" class:list={[{ active: currentPath.includes('/concepts/polecat-lifecycle') }]}>Polecat Lifecycle</a></li>
+          <li><a href="/concepts/propulsion-principle" class:list={[{ active: currentPath.includes('/concepts/propulsion-principle') }]}>Propulsion Principle</a></li>
+        </ul>
+
+        <h3>Design</h3>
+        <ul>
+          <li><a href="/design/architecture" class:list={[{ active: currentPath.includes('/design/architecture') }]}>Architecture</a></li>
+          <li><a href="/design/convoy-lifecycle" class:list={[{ active: currentPath.includes('/design/convoy-lifecycle') }]}>Convoy Lifecycle</a></li>
+          <li><a href="/design/dog-pool-architecture" class:list={[{ active: currentPath.includes('/design/dog-pool-architecture') }]}>Dog Pool Architecture</a></li>
+          <li><a href="/design/escalation" class:list={[{ active: currentPath === '/design/escalation' || currentPath === '/design/escalation/' }]}>Escalation</a></li>
+          <li><a href="/design/escalation-system" class:list={[{ active: currentPath.includes('/design/escalation-system') }]}>Escalation System</a></li>
+          <li><a href="/design/federation" class:list={[{ active: currentPath.includes('/design/federation') }]}>Federation</a></li>
+          <li><a href="/design/mail-protocol" class:list={[{ active: currentPath.includes('/design/mail-protocol') }]}>Mail Protocol</a></li>
+          <li><a href="/design/operational-state" class:list={[{ active: currentPath.includes('/design/operational-state') }]}>Operational State</a></li>
+          <li><a href="/design/plugin-system" class:list={[{ active: currentPath.includes('/design/plugin-system') }]}>Plugin System</a></li>
+          <li><a href="/design/property-layers" class:list={[{ active: currentPath.includes('/design/property-layers') }]}>Property Layers</a></li>
+          <li><a href="/design/watchdog-chain" class:list={[{ active: currentPath.includes('/design/watchdog-chain') }]}>Watchdog Chain</a></li>
+        </ul>
+
+        <h3>Examples</h3>
+        <ul>
+          <li><a href="/examples/hanoi-demo" class:list={[{ active: currentPath.includes('/examples/hanoi-demo') }]}>Hanoi Demo</a></li>
+        </ul>
+
+        <h3>Other</h3>
+        <ul>
+          <li><a href="/beads-native-messaging" class:list={[{ active: currentPath.includes('/beads-native-messaging') }]}>Beads Native Messaging</a></li>
+          <li><a href="/formula-resolution" class:list={[{ active: currentPath.includes('/formula-resolution') }]}>Formula Resolution</a></li>
+          <li><a href="/mol-mall-design" class:list={[{ active: currentPath.includes('/mol-mall-design') }]}>Mol Mall Design</a></li>
+          <li><a href="/why-these-features" class:list={[{ active: currentPath.includes('/why-these-features') }]}>Why These Features</a></li>
+        </ul>
+      </nav>
+    </aside>
+    <article class="docs-content">
+      <h1>{title}</h1>
+      <slot />
+    </article>
+  </div>
+</BaseLayout>
+
+<style>
+  .docs-container {
+    display: flex;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+    gap: 2rem;
+  }
+
+  .docs-sidebar {
+    width: 260px;
+    flex-shrink: 0;
+    background: var(--color-surface);
+    border: 2px solid var(--color-border);
+    border-radius: 4px;
+    padding: 1.5rem;
+    height: fit-content;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.5),
+      0 2px 8px rgba(0, 0, 0, 0.1);
+    animation: fadeIn 0.5s var(--ease-out-expo) both;
+  }
+
+  .docs-sidebar nav h3 {
+    font-family: var(--font-display);
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.5rem;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-text-muted);
+    border-bottom: 2px solid var(--color-brass);
+  }
+
+  .docs-sidebar nav h3:first-child {
+    margin-top: 0;
+  }
+
+  .docs-sidebar ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .docs-sidebar li {
+    margin: 0.25rem 0;
+  }
+
+  .docs-sidebar a {
+    display: block;
+    color: var(--color-text);
+    text-decoration: none;
+    font-size: 0.9rem;
+    padding: 0.375rem 0.75rem;
+    border-radius: 3px;
+    border-left: 3px solid transparent;
+    transition:
+      color var(--duration-fast) var(--ease-in-out-smooth),
+      background var(--duration-fast) var(--ease-in-out-smooth),
+      border-left-color var(--duration-normal) var(--ease-out-expo),
+      padding-left var(--duration-normal) var(--ease-out-expo);
+  }
+
+  .docs-sidebar a:hover {
+    color: var(--color-accent);
+    background: var(--color-bg-alt);
+    border-left-color: var(--color-brass);
+    padding-left: 1rem;
+    text-decoration: none;
+  }
+
+  .docs-sidebar a.active {
+    color: var(--color-accent);
+    background: var(--color-bg-alt);
+    border-left-color: var(--color-brass);
+    font-weight: 600;
+  }
+
+  .docs-content {
+    flex: 1;
+    min-width: 0;
+    background: var(--color-surface);
+    border: 2px solid var(--color-border);
+    border-radius: 4px;
+    padding: 2rem;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.5),
+      0 2px 8px rgba(0, 0, 0, 0.1);
+    animation: fadeInUp 0.6s var(--ease-out-expo) 0.1s both;
+  }
+
+  @media (max-width: 768px) {
+    .docs-container {
+      flex-direction: column;
+      padding: 1rem;
+    }
+
+    .docs-sidebar {
+      width: 100%;
+      position: static;
+    }
+
+    .docs-content {
+      padding: 1.5rem;
+    }
+  }
+</style>

--- a/src-docs/site.config.ts
+++ b/src-docs/site.config.ts
@@ -1,0 +1,23 @@
+/**
+ * Site configuration for the docs subdomain (docs.gastownhall.ai).
+ * Used by Astro components for consistent site-wide values.
+ */
+
+export const site = {
+  name: 'Gas Town Docs',
+  url: 'https://docs.gastownhall.ai',
+  mainSiteUrl: 'https://gastownhall.ai',
+  description: 'Documentation for Gas Town, an open source orchestration layer for AI coding agents.',
+  twitterHandle: '@gastownhall',
+} as const;
+
+export const social = {
+  discord: 'https://discord.gg/pKsyZJ3S',
+  x: 'https://x.com/gastownhall',
+  github: 'https://github.com/steveyegge/gastown',
+} as const;
+
+export const analytics = {
+  plausibleDomain: 'docs.gastownhall.ai',
+  plausibleScript: 'https://plausible.io/js/script.js',
+} as const;

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -6,6 +6,7 @@
 export const site = {
   name: 'Gas Town Hall',
   url: 'https://gastownhall.ai',
+  docsUrl: 'https://docs.gastownhall.ai',
   description: 'Gas Town Hall is the official documentation and community hub for Gas Town, an open source orchestration layer for AI coding agents. Track accountability, measure quality, and scale your AI-assisted engineering workflows.',
   twitterHandle: '@gastownhall',
 } as const;


### PR DESCRIPTION
This enables serving documentation from a dedicated subdomain instead of a subdirectory on the main site. Key changes:

- Add astro.config.docs.mjs for subdomain build configuration
- Add src-docs/ directory with subdomain-specific layouts
- Update shred-docs.mjs to support --subdomain flag for root-level routes
- Update markdown.mjs to handle subdomain link resolution
- Add _redirects for Cloudflare Pages to redirect /docs/* to subdomain
- Update site configs with docsUrl property
- Update BaseLayout to link to docs subdomain
- Update llms.txt generation to use subdomain URLs

New npm scripts:
- shred-docs:subdomain - Generate docs at root level
- build:docs - Build docs subdomain site
- deploy:docs - Deploy to gastownhall-docs Cloudflare Pages project

After deployment, configure docs.gastownhall.ai as custom domain for the gastownhall-docs Cloudflare Pages project.